### PR TITLE
Add updateFiles.py to handle accomodating API changes on Windows

### DIFF
--- a/nanovdb/nanovdb/cmd/updateFiles.py
+++ b/nanovdb/nanovdb/cmd/updateFiles.py
@@ -163,7 +163,7 @@ def update_files(dir_path):
         "util/cuda/CudaGridStats.cuh": "tools/cuda/CudaGridStats.cuh",
         "util/cuda/CudaGridValidator.cuh": "tools/cuda/CudaGridValidator.cuh",
         "util/cuda/CudaIndexToGrid.cuh": "tools/cuda/CudaIndexToGrid.cuh",
-        "util/cuda/CudaPointsToGrid.cuh": "tools/GridChecksum.cuh",
+        "util/cuda/CudaPointsToGrid.cuh": "tools/cuda/PointsToGrid.cuh",
         "util/cuda/CudaSignedFloodFill.cuh": "tools/cuda/CudaSignedFloodFill.cuh",
         "util/cuda/CudaDeviceBuffer.h": "cuda/DeviceBuffer.h",
         "util/cuda/CudaGridHandle.cuh": "cuda/GridHandle.cuh",

--- a/nanovdb/nanovdb/cmd/updateFiles.py
+++ b/nanovdb/nanovdb/cmd/updateFiles.py
@@ -11,12 +11,31 @@ def open_file(file_path):
             The content of the file in an arbitrary format.
     """
     try:
-        with open(file_path, "r", encoding="utf-8", errors="replace") as file:
+        with open(file_path, 'r', encoding='utf-8', errors='replace') as file:
             return file.read()
     except UnicodeDecodeError:
         # If utf-8 decoding fails, try windows-1252.
-        with open(file_path, "r", encoding="windows-1252", errors="replace") as file:
+        with open(file_path, 'r', encoding='windows-1252', errors='replace') as file:
             return file.read()
+
+
+def write_file(file_path, content):
+    """
+        Writes a file.
+
+        Args:
+            file_path: Path of the file to open.
+
+        Returns:
+            The content of the file in an arbitrary format.
+    """
+    try:
+        with open(file_path, 'w', encoding='utf-8', errors='replace') as file:
+            return file.write(content)
+    except UnicodeDecodeError:
+        # If utf-8 decoding fails, try windows-1252.
+        with open(file_path, 'w', encoding='windows-1252', errors='replace') as file:
+            return file.write(content)
 
 def update_files():
     """
@@ -116,8 +135,7 @@ def update_files():
                     new_path = '<nanovdb/' + val + '>'
                     content = content.replace(old_path, new_path)
 
-                with open(file_path, 'w') as file:
-                    file.write(content)
+                write_file(file_path, content)
 
 if __name__ == "__main__":
     update_files()

--- a/nanovdb/nanovdb/cmd/updateFiles.py
+++ b/nanovdb/nanovdb/cmd/updateFiles.py
@@ -47,7 +47,7 @@ def update_files(dir_path):
     include directories.
 
     Args:
-        None.
+        Directory path: will include files in downstream directories.
 
     Returns:
         None. Writes the contents of the file.
@@ -199,7 +199,11 @@ def update_files(dir_path):
 
                 write_file(file_path, content)
 
-
+# Example use:
+# To update all the files using NanoVDB in the current directory (and directories downstream):
+# python ./nanovdb/nanovdb/cmd/updateFiles.py
+# To update all the files using NanoVDB in a directory called foo (and directories downstream):
+# python ./nanovdb/nanovdb/cmd/updateFiles.py -d /path/to/foo
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Synthetic Data Generation for USD")
     parser.add_argument(

--- a/nanovdb/nanovdb/cmd/updateFiles.py
+++ b/nanovdb/nanovdb/cmd/updateFiles.py
@@ -1,113 +1,174 @@
+import argparse
 import os
+from pathlib import Path
+
 
 def open_file(file_path):
     """
-        Opens a file.
+    Opens a file. If utf-8 decoding fails, try windows-1252.
 
-        Args:
-            file_path: Path of the file to open.
+    Args:
+        file_path: Path of the file to open.
 
-        Returns:
-            The content of the file in an arbitrary format.
+    Returns:
+        The content of the file in an arbitrary format.
     """
     try:
-        with open(file_path, 'r', encoding='utf-8', errors='replace') as file:
+        with open(file_path, "r", encoding="utf-8", errors="replace") as file:
             return file.read()
     except UnicodeDecodeError:
-        # If utf-8 decoding fails, try windows-1252.
-        with open(file_path, 'r', encoding='windows-1252', errors='replace') as file:
+        with open(file_path, "r", encoding="windows-1252", errors="replace") as file:
             return file.read()
 
 
 def write_file(file_path, content):
     """
-        Writes a file.
+    Writes a file. If utf-8 decoding fails, try windows-1252.
 
-        Args:
-            file_path: Path of the file to open.
+    Args:
+        file_path: Path of the file to open.
 
-        Returns:
-            The content of the file in an arbitrary format.
+    Returns:
+        None.
     """
     try:
-        with open(file_path, 'w', encoding='utf-8', errors='replace') as file:
-            return file.write(content)
+        with open(file_path, "w", encoding="utf-8", errors="replace") as file:
+            file.write(content)
     except UnicodeDecodeError:
-        # If utf-8 decoding fails, try windows-1252.
-        with open(file_path, 'w', encoding='windows-1252', errors='replace') as file:
-            return file.write(content)
+        with open(file_path, "w", encoding="windows-1252", errors="replace") as file:
+            file.write(content)
 
-def update_files():
+
+def update_files(dir_path):
     """
-        Updates the content of files ending in .h, .cuh, .cc, .cu, and .cpp
-        to call the appropriate API as we update NanoVDB from version 32.6 to
-        version 32.7. This includes changes in namespaces, function names, and
-        include directories.
+    Updates the content of files ending in .h, .cuh, .cc, .cu, and .cpp
+    to call the appropriate API as we update NanoVDB from version 32.6 to
+    version 32.7. This includes changes in namespaces, function names, and
+    include directories.
 
-        Args:
-            None.
+    Args:
+        None.
 
-        Returns:
-            None. Writes the contents of the file.
+    Returns:
+        None. Writes the contents of the file.
     """
-    # Use current working directory to find files
-    dir_path = os.getcwd()
 
     # List of file extensions to search for
-    file_extensions = ['.h', '.cuh', '.cc', '.cu', '.cpp']
+    file_extensions = [".h", ".cuh", ".cc", ".cu", ".cpp"]
 
     nspace_dic = {
-        'math': ['Ray', 'DDA<', 'HDDA', 'Vec3<', 'Vec4<', 'BBox<', 'ZeroCrossing', 'TreeMarcher', 'PointTreeMarcher', 'BoxStencil<', 'CurvatureStencil<', 'GradStencil<', 'WenoStencil<', 'AlignUp', 'Min', 'Max', 'Abs', 'Clamp', 'Sqrt', 'Sign', 'Maximum<', 'Delta<', 'RoundDown<', 'pi<', 'isApproxZero<', 'Round<', 'createSampler', 'SampleFromVoxels<'],
-        'tools': ['createNanoGrid', 'StatsMode', 'createLevelSetSphere', 'createFogVolumeSphere', 'createFogVolumeSphere createFogVolumeSphere', 'createFogVolumeTorus', 'createLevelSetBox', 'CreateNanoGrid', 'updateGridStats', 'evalChecksum', 'validateChecksum', 'checkGrid', 'Extrema'],
-        'util': ['is_floating_point', 'findLowestOn', 'findHighestOn', 'Range', 'streq', 'strcpy', 'strcat', 'empty(', 'Split', 'invoke', 'forEach', 'reduce', 'prefixSum', 'is_same', 'is_specialization', 'PtrAdd', 'PtrDiff'],
+        "math": [
+            "Ray",
+            "DDA<",
+            "HDDA",
+            "Vec3<",
+            "Vec4<",
+            "BBox<",
+            "ZeroCrossing",
+            "TreeMarcher",
+            "PointTreeMarcher",
+            "BoxStencil<",
+            "CurvatureStencil<",
+            "GradStencil<",
+            "WenoStencil<",
+            "AlignUp",
+            "Min",
+            "Max",
+            "Abs",
+            "Clamp",
+            "Sqrt",
+            "Sign",
+            "Maximum<",
+            "Delta<",
+            "RoundDown<",
+            "pi<",
+            "isApproxZero<",
+            "Round<",
+            "createSampler",
+            "SampleFromVoxels<",
+        ],
+        "tools": [
+            "createNanoGrid",
+            "StatsMode",
+            "createLevelSetSphere",
+            "createFogVolumeSphere",
+            "createFogVolumeSphere createFogVolumeSphere",
+            "createFogVolumeTorus",
+            "createLevelSetBox",
+            "CreateNanoGrid",
+            "updateGridStats",
+            "evalChecksum",
+            "validateChecksum",
+            "checkGrid",
+            "Extrema",
+        ],
+        "util": [
+            "is_floating_point",
+            "findLowestOn",
+            "findHighestOn",
+            "Range",
+            "streq",
+            "strcpy",
+            "strcat",
+            "empty(",
+            "Split",
+            "invoke",
+            "forEach",
+            "reduce",
+            "prefixSum",
+            "is_same",
+            "is_specialization",
+            "PtrAdd",
+            "PtrDiff",
+        ],
     }
 
     rename_dic = {
         # list from func4 in updateFiles.sh
-        'nanovdb::build::': 'nanovdb::tools::build::',
-        'nanovdb::BBoxR': 'nanovdb::Vec3dBBox',
-        'nanovdb::BBox<nanovdb::Vec3d>': 'nanovdb::Vec3dBbox',
+        "nanovdb::build::": "nanovdb::tools::build::",
+        "nanovdb::BBoxR": "nanovdb::Vec3dBBox",
+        "nanovdb::BBox<nanovdb::Vec3d>": "nanovdb::Vec3dBbox",
         # scope and rename, i.e. list from func2 in updateFiles.sh
-        'nanovdb::cudaCreateNodeManager': 'nanovdb::cuda::createNodeManager',
-        'nanovdb::cudaVoxelsToGrid': 'nanovdb::cuda::voxelsToGrid',
-        'nanovdb::cudaPointsToGrid': 'nanovdb::cuda::pointsToGrid',
-        'nanovdb::DitherLUT': 'nanovdb::math::DitherLUT',
-        'nanovdb::PackedRGBA8': 'nanovdb::math::Rgba8',
-        'nanovdb::Rgba8': 'nanovdb::math::Rgba8',
-        'nanovdb::CpuTimer': 'nanovdb::util::Timer',
-        'nanovdb::GpuTimer': 'nanovdb::util::cuda::Timer',
-        'nanovdb::CountOn': 'nanovdb::util::countOn',
+        "nanovdb::cudaCreateNodeManager": "nanovdb::cuda::createNodeManager",
+        "nanovdb::cudaVoxelsToGrid": "nanovdb::cuda::voxelsToGrid",
+        "nanovdb::cudaPointsToGrid": "nanovdb::cuda::pointsToGrid",
+        "nanovdb::DitherLUT": "nanovdb::math::DitherLUT",
+        "nanovdb::PackedRGBA8": "nanovdb::math::Rgba8",
+        "nanovdb::Rgba8": "nanovdb::math::Rgba8",
+        "nanovdb::CpuTimer": "nanovdb::util::Timer",
+        "nanovdb::GpuTimer": "nanovdb::util::cuda::Timer",
+        "nanovdb::CountOn": "nanovdb::util::countOn",
     }
 
     movdir_dic = {
-        'util/GridHandle.h': 'GridHandle.h',
-        'util/GridHandle.h': 'HostBuffer.h',
-        'util/BuildGrid.h':   'tools/GridBuilder.h',
-        'util/GridBuilder.h': 'tools/GridBuilder.h',
-        'util/IO.h': 'io/IO.h',
-        'util/CSampleFromVoxels.h': 'math/CSampleFromVoxels.h',
-        'util/DitherLUT.h': 'math/DitherLUT.h',
-        'util/HDDA.h': 'math/HDDA.h',
-        'util/Ray.h': 'math/Ray.h',
-        'util/SampleFromVoxels.h': 'math/SampleFromVoxels.h',
-        'util/Stencils.h': 'nanovdb/math/Stencils.h',
-        'util/CreateNanoGrid.h': 'tools/CreateNanoGrid.h',
-        'util/Primitives.h': 'tools/CreatePrimitives.h',
-        'util/GridChecksum.h': 'tools/GridChecksum.h',
-        'util/GridStats.h': 'tools/GridStats.h',
-        'util/GridChecksum.h': 'tools/GridChecksum.h',
-        'util/GridValidator.h': 'tools/GridValidator.h',
-        'util/NanoToOpenVDB.h': 'tools/NanoToOpenVDB.h',
-        'util/cuda/CudaGridChecksum.cuh': 'tools/cuda/CudaGridChecksum.cuh',
-        'util/cuda/CudaGridStats.cuh': 'tools/cuda/CudaGridStats.cuh',
-        'util/cuda/CudaGridValidator.cuh': 'tools/cuda/CudaGridValidator.cuh',
-        'util/cuda/CudaIndexToGrid.cuh': 'tools/cuda/CudaIndexToGrid.cuh',
-        'util/cuda/CudaPointsToGrid.cuh': 'tools/GridChecksum.cuh',
-        'util/cuda/CudaSignedFloodFill.cuh': 'tools/cuda/CudaSignedFloodFill.cuh',
-        'util/cuda/CudaDeviceBuffer.h': 'cuda/DeviceBuffer.h',
-        'util/cuda/CudaGridHandle.cuh': 'cuda/GridHandle.cuh',
-        'util/cuda/CudaUtils.h': 'util/cuda/Util.h',
-        'util/cuda/GpuTimer.h': 'util/cuda/Timer.h',
+        # list comes from func3 calls on updateFiles.sh
+        "util/GridHandle.h": "GridHandle.h",
+        "util/BuildGrid.h": "tools/GridBuilder.h",
+        "util/GridBuilder.h": "tools/GridBuilder.h",
+        "util/IO.h": "io/IO.h",
+        "util/CSampleFromVoxels.h": "math/CSampleFromVoxels.h",
+        "util/DitherLUT.h": "math/DitherLUT.h",
+        "util/HDDA.h": "math/HDDA.h",
+        "util/Ray.h": "math/Ray.h",
+        "util/SampleFromVoxels.h": "math/SampleFromVoxels.h",
+        "util/Stencils.h": "nanovdb/math/Stencils.h",
+        "util/CreateNanoGrid.h": "tools/CreateNanoGrid.h",
+        "util/Primitives.h": "tools/CreatePrimitives.h",
+        "util/GridChecksum.h": "tools/GridChecksum.h",
+        "util/GridStats.h": "tools/GridStats.h",
+        "util/GridChecksum.h": "tools/GridChecksum.h",
+        "util/GridValidator.h": "tools/GridValidator.h",
+        "util/NanoToOpenVDB.h": "tools/NanoToOpenVDB.h",
+        "util/cuda/CudaGridChecksum.cuh": "tools/cuda/CudaGridChecksum.cuh",
+        "util/cuda/CudaGridStats.cuh": "tools/cuda/CudaGridStats.cuh",
+        "util/cuda/CudaGridValidator.cuh": "tools/cuda/CudaGridValidator.cuh",
+        "util/cuda/CudaIndexToGrid.cuh": "tools/cuda/CudaIndexToGrid.cuh",
+        "util/cuda/CudaPointsToGrid.cuh": "tools/GridChecksum.cuh",
+        "util/cuda/CudaSignedFloodFill.cuh": "tools/cuda/CudaSignedFloodFill.cuh",
+        "util/cuda/CudaDeviceBuffer.h": "cuda/DeviceBuffer.h",
+        "util/cuda/CudaGridHandle.cuh": "cuda/GridHandle.cuh",
+        "util/cuda/CudaUtils.h": "util/cuda/Util.h",
+        "util/cuda/GpuTimer.h": "util/cuda/Timer.h",
     }
 
     # Iterate over files in the directory and its subdirectories
@@ -122,8 +183,9 @@ def update_files():
                 # Correspond to func1 $file in updateFiles.sh
                 for key, vals in nspace_dic.items():
                     for val in vals:
-                        new_word = key + '::' + val
-                        content = content.replace(val, new_word)
+                        old_word = "nanovdb::" + val
+                        new_word = "nanovdb::" + key + "::" + val
+                        content = content.replace(old_word, new_word)
 
                 # Correspond to func4 and func2 in updateFiles.sh
                 for key, val in rename_dic.items():
@@ -131,11 +193,24 @@ def update_files():
 
                 # Correspond to func3 in updateFiles.sh
                 for key, val in movdir_dic.items():
-                    old_path = '<nanovdb/' + key + '>'
-                    new_path = '<nanovdb/' + val + '>'
+                    old_path = "<nanovdb/" + key + ">"
+                    new_path = "<nanovdb/" + val + ">"
                     content = content.replace(old_path, new_path)
 
                 write_file(file_path, content)
 
+
 if __name__ == "__main__":
-    update_files()
+    parser = argparse.ArgumentParser(description="Synthetic Data Generation for USD")
+    parser.add_argument(
+        "-d",
+        "--directory",
+        type=str,
+        default=None,
+        help="Path to directory containing .h, .cc, and .cu files using NanoVDB.",
+    )
+
+    args = parser.parse_args()
+    dir_path = os.getcwd() if args.directory is None else Path(args.directory).resolve()
+
+    update_files(dir_path)

--- a/nanovdb/nanovdb/cmd/updateFiles.py
+++ b/nanovdb/nanovdb/cmd/updateFiles.py
@@ -1,0 +1,123 @@
+import os
+
+def open_file(file_path):
+    """
+        Opens a file.
+
+        Args:
+            file_path: Path of the file to open.
+
+        Returns:
+            The content of the file in an arbitrary format.
+    """
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="replace") as file:
+            return file.read()
+    except UnicodeDecodeError:
+        # If utf-8 decoding fails, try windows-1252.
+        with open(file_path, "r", encoding="windows-1252", errors="replace") as file:
+            return file.read()
+
+def update_files():
+    """
+        Updates the content of files ending in .h, .cuh, .cc, .cu, and .cpp
+        to call the appropriate API as we update NanoVDB from version 32.6 to
+        version 32.7. This includes changes in namespaces, function names, and
+        include directories.
+
+        Args:
+            None.
+
+        Returns:
+            None. Writes the contents of the file.
+    """
+    # Use current working directory to find files
+    dir_path = os.getcwd()
+
+    # List of file extensions to search for
+    file_extensions = ['.h', '.cuh', '.cc', '.cu', '.cpp']
+
+    nspace_dic = {
+        'math': ['Ray', 'DDA<', 'HDDA', 'Vec3<', 'Vec4<', 'BBox<', 'ZeroCrossing', 'TreeMarcher', 'PointTreeMarcher', 'BoxStencil<', 'CurvatureStencil<', 'GradStencil<', 'WenoStencil<', 'AlignUp', 'Min', 'Max', 'Abs', 'Clamp', 'Sqrt', 'Sign', 'Maximum<', 'Delta<', 'RoundDown<', 'pi<', 'isApproxZero<', 'Round<', 'createSampler', 'SampleFromVoxels<'],
+        'tools': ['createNanoGrid', 'StatsMode', 'createLevelSetSphere', 'createFogVolumeSphere', 'createFogVolumeSphere createFogVolumeSphere', 'createFogVolumeTorus', 'createLevelSetBox', 'CreateNanoGrid', 'updateGridStats', 'evalChecksum', 'validateChecksum', 'checkGrid', 'Extrema'],
+        'util': ['is_floating_point', 'findLowestOn', 'findHighestOn', 'Range', 'streq', 'strcpy', 'strcat', 'empty(', 'Split', 'invoke', 'forEach', 'reduce', 'prefixSum', 'is_same', 'is_specialization', 'PtrAdd', 'PtrDiff'],
+    }
+
+    rename_dic = {
+        # list from func4 in updateFiles.sh
+        'nanovdb::build::': 'nanovdb::tools::build::',
+        'nanovdb::BBoxR': 'nanovdb::Vec3dBBox',
+        'nanovdb::BBox<nanovdb::Vec3d>': 'nanovdb::Vec3dBbox',
+        # scope and rename, i.e. list from func2 in updateFiles.sh
+        'nanovdb::cudaCreateNodeManager': 'nanovdb::cuda::createNodeManager',
+        'nanovdb::cudaVoxelsToGrid': 'nanovdb::cuda::voxelsToGrid',
+        'nanovdb::cudaPointsToGrid': 'nanovdb::cuda::pointsToGrid',
+        'nanovdb::DitherLUT': 'nanovdb::math::DitherLUT',
+        'nanovdb::PackedRGBA8': 'nanovdb::math::Rgba8',
+        'nanovdb::Rgba8': 'nanovdb::math::Rgba8',
+        'nanovdb::CpuTimer': 'nanovdb::util::Timer',
+        'nanovdb::GpuTimer': 'nanovdb::util::cuda::Timer',
+        'nanovdb::CountOn': 'nanovdb::util::countOn',
+    }
+
+    movdir_dic = {
+        'util/GridHandle.h': 'GridHandle.h',
+        'util/GridHandle.h': 'HostBuffer.h',
+        'util/BuildGrid.h':   'tools/GridBuilder.h',
+        'util/GridBuilder.h': 'tools/GridBuilder.h',
+        'util/IO.h': 'io/IO.h',
+        'util/CSampleFromVoxels.h': 'math/CSampleFromVoxels.h',
+        'util/DitherLUT.h': 'math/DitherLUT.h',
+        'util/HDDA.h': 'math/HDDA.h',
+        'util/Ray.h': 'math/Ray.h',
+        'util/SampleFromVoxels.h': 'math/SampleFromVoxels.h',
+        'util/Stencils.h': 'nanovdb/math/Stencils.h',
+        'util/CreateNanoGrid.h': 'tools/CreateNanoGrid.h',
+        'util/Primitives.h': 'tools/CreatePrimitives.h',
+        'util/GridChecksum.h': 'tools/GridChecksum.h',
+        'util/GridStats.h': 'tools/GridStats.h',
+        'util/GridChecksum.h': 'tools/GridChecksum.h',
+        'util/GridValidator.h': 'tools/GridValidator.h',
+        'util/NanoToOpenVDB.h': 'tools/NanoToOpenVDB.h',
+        'util/cuda/CudaGridChecksum.cuh': 'tools/cuda/CudaGridChecksum.cuh',
+        'util/cuda/CudaGridStats.cuh': 'tools/cuda/CudaGridStats.cuh',
+        'util/cuda/CudaGridValidator.cuh': 'tools/cuda/CudaGridValidator.cuh',
+        'util/cuda/CudaIndexToGrid.cuh': 'tools/cuda/CudaIndexToGrid.cuh',
+        'util/cuda/CudaPointsToGrid.cuh': 'tools/GridChecksum.cuh',
+        'util/cuda/CudaSignedFloodFill.cuh': 'tools/cuda/CudaSignedFloodFill.cuh',
+        'util/cuda/CudaDeviceBuffer.h': 'cuda/DeviceBuffer.h',
+        'util/cuda/CudaGridHandle.cuh': 'cuda/GridHandle.cuh',
+        'util/cuda/CudaUtils.h': 'util/cuda/Util.h',
+        'util/cuda/GpuTimer.h': 'util/cuda/Timer.h',
+    }
+
+    # Iterate over files in the directory and its subdirectories
+    for root, dirs, files in os.walk(dir_path):
+        for file in files:
+            if any(file.endswith(ext) for ext in file_extensions):
+                file_path = os.path.join(root, file)
+                print(f"Processing file: {file_path}")
+
+                content = open_file(file_path)
+
+                # Correspond to func1 $file in updateFiles.sh
+                for key, vals in nspace_dic.items():
+                    for val in vals:
+                        new_word = key + '::' + val
+                        content = content.replace(val, new_word)
+
+                # Correspond to func4 and func2 in updateFiles.sh
+                for key, val in rename_dic.items():
+                    content = content.replace(key, val)
+
+                # Correspond to func3 in updateFiles.sh
+                for key, val in movdir_dic.items():
+                    old_path = '<nanovdb/' + key + '>'
+                    new_path = '<nanovdb/' + val + '>'
+                    content = content.replace(old_path, new_path)
+
+                with open(file_path, 'w') as file:
+                    file.write(content)
+
+if __name__ == "__main__":
+    update_files()

--- a/nanovdb/nanovdb/cmd/updateFiles.sh
+++ b/nanovdb/nanovdb/cmd/updateFiles.sh
@@ -69,7 +69,6 @@ for file in $(find "$dir" -name '*.h' -or -name '*.cuh' -or -name '*.cc' -or -na
     func2 $file util GpuTimer "cuda::Timer"
     func2 $file util CountOn countOn
     func3 $file "util/GridHandle.h" "GridHandle.h"
-    func3 $file "util/GridHandle.h" "HostBuffer.h"
     func3 $file "util/BuildGrid.h"   "tools/GridBuilder.h"
     func3 $file "util/GridBuilder.h" "tools/GridBuilder.h"
     func3 $file "util/IO.h" "io/IO.h"

--- a/nanovdb/nanovdb/cmd/updateFiles.sh
+++ b/nanovdb/nanovdb/cmd/updateFiles.sh
@@ -89,7 +89,7 @@ for file in $(find "$dir" -name '*.h' -or -name '*.cuh' -or -name '*.cc' -or -na
     func3 $file "util/cuda/CudaGridStats.cuh" "tools/cuda/CudaGridStats.cuh"
     func3 $file "util/cuda/CudaGridValidator.cuh" "tools/cuda/CudaGridValidator.cuh"
     func3 $file "util/cuda/CudaIndexToGrid.cuh" "tools/cuda/CudaIndexToGrid.cuh"
-    func3 $file "util/cuda/CudaPointsToGrid.cuh" "tools/GridChecksum.cuh"
+    func3 $file "util/cuda/CudaPointsToGrid.cuh" "tools/cuda/PointsToGrid.cuh"
     func3 $file "util/cuda/CudaSignedFloodFill.cuh" "tools/cuda/CudaSignedFloodFill.cuh"
     func3 $file "util/cuda/CudaDeviceBuffer.h" "cuda/DeviceBuffer.h"
     func3 $file "util/cuda/CudaGridHandle.cuh" "cuda/GridHandle.cuh"

--- a/pendingchanges/nanovdb_32.7.txt
+++ b/pendingchanges/nanovdb_32.7.txt
@@ -1,0 +1,85 @@
+Bug fix:
+nanovdb::readGrids works with raw grid buffer.
+
+Improvements:
+Restructure files location and namespace to be more align with OpenVDB. The
+namespaces touched by the restructuring are: io, cuda, util, tools, and math.
+Add two scripts updateFiles.sh and updateFiles.py to update the files using
+NanoVDB. The script updateFiles.py works on both Windows and Linux.
+For a more complete list of changes, see API Changes (details).
+
+cuda::PointsToGrid supports target density.
+Add support for NanoVDB Grid of type UInt8.
+Add ability to use externally managed CUDA buffer.
+Add create methods for CudaDeviceBuffer and exceptions.
+Improve GridValidator logic, e.g. include check for grid count.
+Add operator > and >= for class Coord according to lexicographical order.
+Add toCodec to convert string to Codec enumeration type.
+Add nanovdb::strlen<GridType>().
+Add strncpy util.
+Add NANOVDB_DISABLE_SYNC_CUDA_MALLOC that maps cudaMallocAsync and
+cudaFreeAsync to cudaMalloc and cudaFree respectively.
+Add guard to UINT64_C.
+Remove use of cudaMallocAsync in PointsToGrid.cuh.
+Align PNanoVDB blind metadata to NanoVDB.
+
+API Changes:
+Change mapToGridType to toGridType.
+Change mapToMagic to toMagic.
+Change CpuTimer.h to Timer.h.
+
+API Changes (details):
+These APIs are now under the math namespace: Ray, DDA, HDDA, Vec3, Vec4, BBox,
+ZeroCrossing, TreeMarcher, PointTreeMarcher, BoxStencil, CurvatureStencil,
+GradStencil, WenoStencil, AlignUp, Min, Max, Abs, Clamp, Sqrt, Sign, Maximum,
+Delta, RoundDown, pi, isApproxZero, Round, createSampler, SampleFromVoxels.
+
+These APIs are now under the tools namespace: createNanoGrid, StatsMode,
+createLevelSetSphere, createFogVolumeSphere, createFogVolumeSphere,
+createFogVolumeSphere, createFogVolumeTorus, createLevelSetBox, CreateNanoGrid,
+updateGridStats, evalChecksum, validateChecksum, checkGrid, Extrema.
+
+These APIs are now under the util namespace: is_floating_point, findLowestOn,
+findHighestOn, Range, streq, strcpy, strcat, empty, Split, invoke, forEach,
+reduce, prefixSum, is_same, is_specialization, PtrAdd, PtrDiff.
+
+Move nanovdb::build to nanovdb::tools::build.
+Rename nanovdb::BBoxR to nanovdb::Vec3dBBox.
+Rename nanovdb::BBox<nanovdb::Vec3d> to nanovdb::Vec3dBbox.
+Move nanovdb::cudaCreateNodeManager to nanovdb::cuda::createNodeManager.
+Move and rename nanovdb::cudaVoxelsToGrid to nanovdb::cuda::voxelsToGrid.
+Move and rename nanovdb::cudaPointsToGrid to nanovdb::cuda::pointsToGrid.
+Move nanovdb::DitherLUT to nanovdb::math::DitherLUT.
+Move and rename nanovdb::PackedRGBA8 to nanovdb::math::Rgba8.
+Move nanovdb::Rgba8 to nanovdb::math::Rgba8.
+Move and rename nanovdb::CpuTimer to nanovdb::util::Timer.
+Move nanovdb::GpuTimer to nanovdb::util::cuda::Timer.
+Move and rename nanovdb::CountOn to nanovdb::util::countOn.
+
+Move util/GridHandle.h to GridHandle.h.
+Move util/BuildGrid.h to tools/GridBuilder.h.
+Move util/GridBuilder.h to tools/GridBuilder.h.
+Move util/IO.h to io/IO.h.
+Move util/CSampleFromVoxels.h to math/CSampleFromVoxels.h.
+Move util/DitherLUT.h to math/DitherLUT.h.
+Move util/HDDA.h to math/HDDA.h.
+Move util/Ray.h to math/Ray.h.
+Move util/SampleFromVoxels.h to math/SampleFromVoxels.h.
+Move util/Stencils.h to nanovdb/math/Stencils.h.
+Move util/CreateNanoGrid.h to tools/CreateNanoGrid.h.
+Move and rename util/Primitives.h to tools/CreatePrimitives.h.
+Move util/GridChecksum.h to tools/GridChecksum.h.
+Move util/GridStats.h to tools/GridStats.h.
+Move util/GridChecksum.h to tools/GridChecksum.h.
+Move util/GridValidator.h to tools/GridValidator.h.
+Move util/NanoToOpenVDB.h to tools/NanoToOpenVDB.h.
+Move util/cuda/CudaGridChecksum.cuh to tools/cuda/CudaGridChecksum.cuh.
+Move util/cuda/CudaGridStats.cuh to tools/cuda/CudaGridStats.cuh.
+Move util/cuda/CudaGridValidator.cuh to tools/cuda/CudaGridValidator.cuh.
+Move util/cuda/CudaIndexToGrid.cuh to tools/cuda/CudaIndexToGrid.cuh.
+Move and rename util/cuda/CudaPointsToGrid.cuh to tools/cuda/PointsToGrid.cuh.
+Move util/cuda/CudaSignedFloodFill.cuh to tools/cuda/CudaSignedFloodFill.cuh.
+Move and rename util/cuda/CudaDeviceBuffer.h to cuda/DeviceBuffer.h.
+Move and rename util/cuda/CudaGridHandle.cuh to cuda/GridHandle.cuh.
+Move and rename util/cuda/CudaUtils.h to util/cuda/Util.h.
+Move and consolidate util/cuda/GpuTimer.h to util/cuda/Timer.h.


### PR DESCRIPTION
This PR adds updateFiles.py to handle how we are updating the files on Windows when we move from NanoVDB 32.6 to NanoVDB 32.7. There are two more checks I want to do before this gets merge.