### PR TITLE
Add Python bindings for polySoupToLevelSet and shrink-wrap utility

### DIFF
--- a/openvdb/openvdb/python/pyGrid.h
+++ b/openvdb/openvdb/python/pyGrid.h
@@ -19,6 +19,7 @@
 #include <nanobind/stl/optional.h>
 #include <openvdb/tools/MeshToVolume.h>
 #include <openvdb/tools/VolumeToMesh.h> // for tools::volumeToMesh()
+#include <openvdb/tools/PolySoupToLevelSet.h>
 #include <openvdb/openvdb.h>
 #include <openvdb/io/Stream.h>
 #include <openvdb/math/Math.h> // for math::isExactlyEqual()
@@ -562,6 +563,167 @@ meshToSignedDistanceField(
         math::Transform::Ptr identity = math::Transform::createLinearTransform();
         return tools::meshToSignedDistanceField<GridType>(*identity, points, triangles, quads, exBandWidth, inBandWidth);
     }
+}
+
+/// @brief Call tools::polySoupToLevelSet() with explicit voxel size range
+template<typename GridType>
+inline nb::list
+polySoupToLevelSet(
+    float minVoxelSize,
+    float maxVoxelSize,
+    nb::ndarray<float, nb::shape<-1, 3>, nb::device::cpu> pointsObj,
+    std::optional<nb::ndarray<Index32, nb::shape<-1, 3>, nb::device::cpu>>& trianglesObj,
+    std::optional<nb::ndarray<Index32, nb::shape<-1, 4>, nb::device::cpu>>& quadsObj,
+    float erode,
+    float thres,
+    float halfWidth)
+{
+    // Extract vertices
+    std::vector<Vec3s> points(pointsObj.shape(0));
+    for (size_t i = 0; i < pointsObj.shape(0); ++i)
+        points[i] = Vec3s(pointsObj(i, 0), pointsObj(i, 1), pointsObj(i, 2));
+
+    // Extract triangles
+    std::vector<Vec3I> triangles;
+    if (trianglesObj) {
+        triangles.resize(trianglesObj->shape(0));
+        for (size_t i = 0; i < trianglesObj->shape(0); ++i)
+            triangles[i] = Vec3I((*trianglesObj)(i, 0), (*trianglesObj)(i, 1), (*trianglesObj)(i, 2));
+    }
+
+    // Extract quads
+    std::vector<Vec4I> quads;
+    if (quadsObj) {
+        quads.resize(quadsObj->shape(0));
+        for (size_t i = 0; i < quadsObj->shape(0); ++i)
+            quads[i] = Vec4I((*quadsObj)(i, 0), (*quadsObj)(i, 1), (*quadsObj)(i, 2), (*quadsObj)(i, 3));
+    }
+
+    // Create ShrinkWrapLimit functor with user parameters
+    tools::ShrinkWrapLimit shrinkWrap(erode, thres);
+
+    // Call C++ function
+    std::vector<typename GridType::Ptr> grids =
+        tools::polySoupToLevelSet<GridType>(
+            minVoxelSize, maxVoxelSize, points, triangles, quads,
+            shrinkWrap, halfWidth);
+
+    // Convert vector to Python list
+    nb::list result;
+    for (const auto& grid : grids) {
+        result.append(grid);
+    }
+    return result;
+}
+
+/// @brief Call tools::polySoupToLevelSet() with dimension and bounding box
+template<typename GridType>
+inline nb::list
+polySoupToLevelSetFromDimension(
+    int dim,
+    const Vec3f& bboxMin,
+    const Vec3f& bboxMax,
+    nb::ndarray<float, nb::shape<-1, 3>, nb::device::cpu> pointsObj,
+    std::optional<nb::ndarray<Index32, nb::shape<-1, 3>, nb::device::cpu>>& trianglesObj,
+    std::optional<nb::ndarray<Index32, nb::shape<-1, 4>, nb::device::cpu>>& quadsObj,
+    float erode,
+    float thres,
+    float halfWidth)
+{
+    // Extract vertices
+    std::vector<Vec3s> points(pointsObj.shape(0));
+    for (size_t i = 0; i < pointsObj.shape(0); ++i)
+        points[i] = Vec3s(pointsObj(i, 0), pointsObj(i, 1), pointsObj(i, 2));
+
+    // Extract triangles
+    std::vector<Vec3I> triangles;
+    if (trianglesObj) {
+        triangles.resize(trianglesObj->shape(0));
+        for (size_t i = 0; i < trianglesObj->shape(0); ++i)
+            triangles[i] = Vec3I((*trianglesObj)(i, 0), (*trianglesObj)(i, 1), (*trianglesObj)(i, 2));
+    }
+
+    // Extract quads
+    std::vector<Vec4I> quads;
+    if (quadsObj) {
+        quads.resize(quadsObj->shape(0));
+        for (size_t i = 0; i < quadsObj->shape(0); ++i)
+            quads[i] = Vec4I((*quadsObj)(i, 0), (*quadsObj)(i, 1), (*quadsObj)(i, 2), (*quadsObj)(i, 3));
+    }
+
+    // Construct BBox internally from min/max parameters
+    math::BBox<Vec3f> bbox(bboxMin, bboxMax);
+
+    // Create ShrinkWrapLimit functor with user parameters
+    tools::ShrinkWrapLimit shrinkWrap(erode, thres);
+
+    // Call C++ function with dimension overload
+    std::vector<typename GridType::Ptr> grids =
+        tools::polySoupToLevelSet<GridType>(
+            dim, bbox, points, triangles, quads,
+            shrinkWrap, halfWidth);
+
+    // Convert to Python list
+    nb::list result;
+    for (const auto& grid : grids) {
+        result.append(grid);
+    }
+    return result;
+}
+
+/// @brief Call tools::polySoupToLevelSet() with minVoxelSize and bounding box
+template<typename GridType>
+inline nb::list
+polySoupToLevelSetFromMinVoxelSize(
+    float minVoxelSize,
+    const Vec3f& bboxMin,
+    const Vec3f& bboxMax,
+    nb::ndarray<float, nb::shape<-1, 3>, nb::device::cpu> pointsObj,
+    std::optional<nb::ndarray<Index32, nb::shape<-1, 3>, nb::device::cpu>>& trianglesObj,
+    std::optional<nb::ndarray<Index32, nb::shape<-1, 4>, nb::device::cpu>>& quadsObj,
+    float erode,
+    float thres,
+    float halfWidth)
+{
+    // Extract vertices
+    std::vector<Vec3s> points(pointsObj.shape(0));
+    for (size_t i = 0; i < pointsObj.shape(0); ++i)
+        points[i] = Vec3s(pointsObj(i, 0), pointsObj(i, 1), pointsObj(i, 2));
+
+    // Extract triangles
+    std::vector<Vec3I> triangles;
+    if (trianglesObj) {
+        triangles.resize(trianglesObj->shape(0));
+        for (size_t i = 0; i < trianglesObj->shape(0); ++i)
+            triangles[i] = Vec3I((*trianglesObj)(i, 0), (*trianglesObj)(i, 1), (*trianglesObj)(i, 2));
+    }
+
+    // Extract quads
+    std::vector<Vec4I> quads;
+    if (quadsObj) {
+        quads.resize(quadsObj->shape(0));
+        for (size_t i = 0; i < quadsObj->shape(0); ++i)
+            quads[i] = Vec4I((*quadsObj)(i, 0), (*quadsObj)(i, 1), (*quadsObj)(i, 2), (*quadsObj)(i, 3));
+    }
+
+    // Construct BBox internally from min/max parameters
+    math::BBox<Vec3f> bbox(bboxMin, bboxMax);
+
+    // Create ShrinkWrapLimit functor with user parameters
+    tools::ShrinkWrapLimit shrinkWrap(erode, thres);
+
+    // Call C++ function with minVoxelSize + bbox overload
+    std::vector<typename GridType::Ptr> grids =
+        tools::polySoupToLevelSet<GridType>(
+            minVoxelSize, bbox, points, triangles, quads,
+            shrinkWrap, halfWidth);
+
+    // Convert to Python list
+    nb::list result;
+    for (const auto& grid : grids) {
+        result.append(grid);
+    }
+    return result;
 }
 
 template<typename GridType, typename std::enable_if_t<!std::is_scalar<typename GridType::ValueType>::value>* = nullptr>
@@ -1291,10 +1453,84 @@ exportGrid(nb::module_ m)
              "Either the triangle or the quad array may be empty or None.\n"
              "The resulting volume will have the given transform (or the identity\n"
              "transform if no transform is given) and a narrow band width of\n"
-             "exBandWidth exterior voxels and inBandWidth interior voxels.")
+             "exBandWidth exterior voxels and inBandWidth interior voxels.");
 
+    // Add polySoupToLevelSet methods only for floating-point grids
+    if constexpr (std::is_floating_point<typename GridType::ValueType>::value) {
+        typedGridClass
+            .def_static("convertPolygonSoupToLevelSet",
+                &pyGrid::polySoupToLevelSet<GridType>,
+                nb::arg("minVoxelSize"),
+                nb::arg("maxVoxelSize"),
+                nb::arg("points"),
+                nb::arg("triangles") = nb::none(),
+                nb::arg("quads") = nb::none(),
+                nb::arg("erode") = 8.0f,
+                nb::arg("thres") = 0.0f,
+                nb::arg("halfWidth") = float(LEVEL_SET_HALF_WIDTH),
+                "Generate LOD family of level sets from polygon soup.\n\n"
+                "Args:\n"
+                "    minVoxelSize: Smallest voxel size for finest grid\n"
+                "    maxVoxelSize: Largest voxel size for coarsest grid\n"
+                "    points: Nx3 array of vertex positions\n"
+                "    triangles: Mx3 array of triangle indices (optional)\n"
+                "    quads: Kx4 array of quad indices (optional)\n"
+                "    erode: Maximum deformation allowed (default: 8.0)\n"
+                "    thres: Engineering threshold (default: 0.0)\n"
+                "    halfWidth: Half-width of narrow band (default: 3.0)\n\n"
+                "Returns:\n"
+                "    List of grids from finest to coarsest resolution")
+            .def_static("convertPolygonSoupToLevelSet",
+                &pyGrid::polySoupToLevelSetFromDimension<GridType>,
+                nb::arg("dim"),
+                nb::arg("bboxMin"),
+                nb::arg("bboxMax"),
+                nb::arg("points"),
+                nb::arg("triangles") = nb::none(),
+                nb::arg("quads") = nb::none(),
+                nb::arg("erode") = 8.0f,
+                nb::arg("thres") = 0.0f,
+                nb::arg("halfWidth") = float(LEVEL_SET_HALF_WIDTH),
+                "Generate LOD family from dimension and bounding box.\n\n"
+                "Args:\n"
+                "    dim: Largest voxel dimension for finest grid\n"
+                "    bboxMin: Minimum corner of bounding box (tuple or Vec3)\n"
+                "    bboxMax: Maximum corner of bounding box (tuple or Vec3)\n"
+                "    points: Nx3 array of vertex positions\n"
+                "    triangles: Mx3 array of triangle indices (optional)\n"
+                "    quads: Kx4 array of quad indices (optional)\n"
+                "    erode: Maximum deformation allowed (default: 8.0)\n"
+                "    thres: Engineering threshold (default: 0.0)\n"
+                "    halfWidth: Half-width of narrow band (default: 3.0)\n\n"
+                "Returns:\n"
+                "    List of grids from finest to coarsest resolution")
+            .def_static("convertPolygonSoupToLevelSet",
+                &pyGrid::polySoupToLevelSetFromMinVoxelSize<GridType>,
+                nb::arg("minVoxelSize"),
+                nb::arg("bboxMin"),
+                nb::arg("bboxMax"),
+                nb::arg("points"),
+                nb::arg("triangles") = nb::none(),
+                nb::arg("quads") = nb::none(),
+                nb::arg("erode") = 8.0f,
+                nb::arg("thres") = 0.0f,
+                nb::arg("halfWidth") = float(LEVEL_SET_HALF_WIDTH),
+                "Generate LOD family from minVoxelSize and bounding box.\n\n"
+                "Args:\n"
+                "    minVoxelSize: Smallest voxel size for finest grid\n"
+                "    bboxMin: Minimum corner of bounding box (tuple or Vec3)\n"
+                "    bboxMax: Maximum corner of bounding box (tuple or Vec3)\n"
+                "    points: Nx3 array of vertex positions\n"
+                "    triangles: Mx3 array of triangle indices (optional)\n"
+                "    quads: Kx4 array of quad indices (optional)\n"
+                "    erode: Maximum deformation allowed (default: 8.0)\n"
+                "    thres: Engineering threshold (default: 0.0)\n"
+                "    halfWidth: Half-width of narrow band (default: 3.0)\n\n"
+                "Returns:\n"
+                "    List of grids from finest to coarsest resolution");
+    }
 
-        .def("prune", &pyGrid::prune<GridType>,
+    typedGridClass.def("prune", &pyGrid::prune<GridType>,
             nb::arg("tolerance") = 0,
             "Remove nodes whose values all have the same active state and are equal to within a given tolerance.")
         .def("pruneInactive", &pyGrid::pruneInactive<GridType>,

--- a/openvdb/openvdb/python/test/TestOpenVDB.py
+++ b/openvdb/openvdb/python/test/TestOpenVDB.py
@@ -796,6 +796,159 @@ class TestOpenVDB(unittest.TestCase):
             self.assertTrue(98 < pmax[2] < 102)
 
 
+    def testConvertPolygonSoupToLevelSet(self):
+        # Test polygon soup to LOD level set conversion.
+
+        # Generate the vertices of a cube.
+        cubeVertices = [(x, y, z) for x in (0, 100) for y in (0, 100) for z in (0, 100)]
+        cubePoints = np.array(cubeVertices, dtype=np.float32)
+
+        # Generate the faces of a cube as quads.
+        cubeQuads = np.array([
+            (0, 1, 3, 2), # left
+            (0, 2, 6, 4), # front
+            (4, 6, 7, 5), # right
+            (5, 7, 3, 1), # back
+            (2, 3, 7, 6), # top
+            (0, 4, 5, 1), # bottom
+        ], dtype=np.uint32)
+
+        # Generate some triangles for testing
+        cubeTriangles = np.array([
+            (0, 1, 2),
+            (4, 5, 6),
+        ], dtype=np.uint32)
+
+        minVoxelSize = 2.0
+        maxVoxelSize = 8.0
+        halfWidth = 3.0
+
+        # Only scalar, floating-point grids support convertPolygonSoupToLevelSet()
+        # (and the OpenVDB module might have been compiled without DoubleGrid support).
+        for gridType in [n for n in openvdb.GridTypes
+            if n.__name__ in ('FloatGrid', 'DoubleGrid')]:
+
+            # Test basic quad mesh conversion
+            grids = gridType.convertPolygonSoupToLevelSet(
+                minVoxelSize=minVoxelSize,
+                maxVoxelSize=maxVoxelSize,
+                points=cubePoints,
+                quads=cubeQuads,
+                halfWidth=halfWidth)
+
+            # Should return a list of grids (LOD family)
+            self.assertIsInstance(grids, list)
+            self.assertGreater(len(grids), 0)
+
+            # Verify each grid in the LOD family
+            for i, grid in enumerate(grids):
+                self.assertIsInstance(grid, gridType)
+
+                # Each successive grid should have larger voxel size
+                voxelSize = grid.transform.voxelSize()[0]
+                if i == 0:
+                    # First grid should have smallest voxel size
+                    self.assertAlmostEqual(voxelSize, minVoxelSize, delta=0.01)
+
+                # All grids should have some active voxels
+                self.assertGreater(grid.activeVoxelCount(), 0)
+
+                # Background should be halfWidth * voxelSize
+                self.assertAlmostEqual(grid.background, halfWidth * voxelSize, delta=0.01)
+
+            # Test with triangles only
+            grids_tri = gridType.convertPolygonSoupToLevelSet(
+                minVoxelSize=minVoxelSize,
+                maxVoxelSize=maxVoxelSize,
+                points=cubePoints,
+                triangles=cubeTriangles,
+                halfWidth=halfWidth)
+
+            self.assertIsInstance(grids_tri, list)
+            self.assertGreater(len(grids_tri), 0)
+
+            # Test with mixed triangles and quads
+            grids_mixed = gridType.convertPolygonSoupToLevelSet(
+                minVoxelSize=minVoxelSize,
+                maxVoxelSize=maxVoxelSize,
+                points=cubePoints,
+                triangles=cubeTriangles,
+                quads=cubeQuads,
+                halfWidth=halfWidth)
+
+            self.assertIsInstance(grids_mixed, list)
+            self.assertGreater(len(grids_mixed), 0)
+
+            # Test with custom erode and thres parameters
+            grids_custom = gridType.convertPolygonSoupToLevelSet(
+                minVoxelSize=minVoxelSize,
+                maxVoxelSize=maxVoxelSize,
+                points=cubePoints,
+                quads=cubeQuads,
+                erode=12.0,
+                thres=0.1,
+                halfWidth=4.0)
+
+            self.assertIsInstance(grids_custom, list)
+            self.assertGreater(len(grids_custom), 0)
+            # Custom halfWidth should affect background value
+            for grid in grids_custom:
+                voxelSize = grid.transform.voxelSize()[0]
+                self.assertAlmostEqual(grid.background, 4.0 * voxelSize, delta=0.01)
+
+            # Test dimension + bboxMin + bboxMax overload
+            bboxMin = (0.0, 0.0, 0.0)
+            bboxMax = (100.0, 100.0, 100.0)
+
+            grids_bbox1 = gridType.convertPolygonSoupToLevelSet(
+                dim=128,
+                bboxMin=bboxMin,
+                bboxMax=bboxMax,
+                points=cubePoints,
+                quads=cubeQuads,
+                halfWidth=halfWidth)
+
+            self.assertIsInstance(grids_bbox1, list)
+            self.assertGreater(len(grids_bbox1), 0)
+
+            # Verify grids have correct properties
+            for grid in grids_bbox1:
+                self.assertIsInstance(grid, gridType)
+                self.assertGreater(grid.activeVoxelCount(), 0)
+                voxelSize = grid.transform.voxelSize()[0]
+                self.assertAlmostEqual(grid.background, halfWidth * voxelSize, delta=0.01)
+
+            # Test minVoxelSize + bboxMin + bboxMax overload
+            grids_bbox2 = gridType.convertPolygonSoupToLevelSet(
+                minVoxelSize=minVoxelSize,
+                bboxMin=bboxMin,
+                bboxMax=bboxMax,
+                points=cubePoints,
+                quads=cubeQuads,
+                halfWidth=halfWidth)
+
+            self.assertIsInstance(grids_bbox2, list)
+            self.assertGreater(len(grids_bbox2), 0)
+
+            # First grid should have the specified minVoxelSize
+            if len(grids_bbox2) > 0:
+                firstVoxelSize = grids_bbox2[0].transform.voxelSize()[0]
+                self.assertAlmostEqual(firstVoxelSize, minVoxelSize, delta=0.01)
+
+            # Verify each grid has correct properties
+            for grid in grids_bbox2:
+                self.assertIsInstance(grid, gridType)
+                self.assertGreater(grid.activeVoxelCount(), 0)
+                voxelSize = grid.transform.voxelSize()[0]
+                self.assertAlmostEqual(grid.background, halfWidth * voxelSize, delta=0.01)
+
+        # Boolean-valued grids should not have convertPolygonSoupToLevelSet()
+        self.assertFalse(hasattr(openvdb.BoolGrid, 'convertPolygonSoupToLevelSet'))
+
+        # Vector-valued grids should not have convertPolygonSoupToLevelSet()
+        self.assertFalse(hasattr(openvdb.Vec3SGrid, 'convertPolygonSoupToLevelSet'))
+
+
 if __name__ == '__main__':
     print('Testing %s' % os.path.dirname(openvdb.__file__))
     sys.stdout.flush()

--- a/shrink-wrap-python/README.md
+++ b/shrink-wrap-python/README.md
@@ -1,0 +1,232 @@
+# OpenVDB Python Examples
+
+This directory contains example scripts demonstrating the use of OpenVDB's Python bindings.
+
+## Available Examples
+
+### shrink_wrap.py
+
+Converts USD mesh files to OpenVDB level sets with optional mesh reconstruction.
+
+#### Features
+
+- **USD Mesh Reading**: Uses Pixar's USD library (`pxr.Usd`) to read mesh geometry
+- **Level Set Conversion**: Converts polygon soup to level set volumes with LOD pyramid generation
+- **Multiple Conversion Modes**:
+  - Voxel size-based (automatic or manual bbox)
+  - Dimension-based with explicit bounding box
+  - Supports both triangles and quads
+- **Mesh Reconstruction**: Optional conversion back to mesh with adaptive polygonization
+- **Output Formats**:
+  - VDB files with multiple LOD grids
+  - USD mesh files
+
+#### Dependencies
+
+```bash
+# Required
+pip install numpy usd-core
+
+# OpenVDB Python bindings must be built and available
+# See main OpenVDB documentation for building Python bindings
+```
+
+#### Usage
+
+**Basic conversion to VDB** (creates `input-out.vdb`):
+```bash
+python shrink_wrap.py input.usd --voxel 0.1
+```
+
+**Convert to VDB with custom parameters:**
+```bash
+python shrink_wrap.py input.usd \
+    --voxel 0.05 \
+    --erode 10.0 \
+    --half-width 4.0
+```
+
+**Use dimension-based sizing:**
+```bash
+python shrink_wrap.py input.usd \
+    --dim 256 \
+    --bbox-min -10 -10 -10 \
+    --bbox-max 10 10 10
+```
+
+**Convert to mesh with adaptivity** (creates `input-out.usd`):
+```bash
+python shrink_wrap.py input.usd \
+    --to-mesh \
+    --voxel 0.1 \
+    --adaptivity 0.005
+```
+
+**Save only finest grid:**
+```bash
+python shrink_wrap.py input.usd \
+    --voxel 0.1 \
+    --finest-only
+```
+
+#### Command-Line Arguments
+
+**Required:**
+- `input.usd`: Input USD mesh file
+
+**Output:**
+- Output filename is auto-generated from input filename:
+  - Default (VDB): `<input_basename>-out.vdb`
+  - With `--to-mesh`: `<input_basename>-out.usd`
+  - Multi-LOD mesh: `<input_basename>-out_lod0.usd`, `<input_basename>-out_lod1.usd`, etc.
+- Output is created in the same directory as the input file
+
+**Conversion Mode:**
+- `--to-mesh`: Convert grids back to mesh (output as USD)
+
+**Level Set Parameters (one required):**
+- `--voxel FLOAT`: Voxel size for finest level set (required, uses minVoxelSize + bbox)
+- `--dim INT`: Grid dimension for finest level (uses dimension + bbox)
+- `--bbox-min X Y Z`: Bounding box minimum (optional, auto-computed if not provided)
+- `--bbox-max X Y Z`: Bounding box maximum (optional, auto-computed if not provided)
+- `--erode FLOAT`: Maximum deformation allowed (default: 8.0)
+- `--threshold FLOAT`: Closing threshold (default: 0.0)
+- `--half-width FLOAT`: Narrow band half-width in voxels (default: 3.0)
+
+**Mesh Conversion Parameters:**
+- `--adaptivity FLOAT`: Mesh adaptivity for convertToPolygons (0-1, default: 0.0)
+  - 0 = high detail (no simplification)
+  - 1 = maximum simplification
+- `--isovalue FLOAT`: Isovalue for mesh extraction (default: 0.0)
+
+**Output Options:**
+- `--finest-only`: Only write finest grid (do not write entire LOD pyramid)
+
+#### Technical Details
+
+**LOD Pyramid Generation:**
+
+The script uses OpenVDB's `convertPolygonSoupToLevelSet` which generates multiple level-of-detail grids:
+- Grid 0: Finest resolution (smallest voxel size)
+- Grid 1+: Progressively coarser resolutions
+
+The LOD pyramid automatically generates multiple resolution levels based on the input parameters.
+
+**Two Conversion Modes:**
+
+1. **Voxel Size Mode**:
+   ```bash
+   --voxel 0.1
+   ```
+   Specifies minimum voxel size. Bounding box is auto-computed from mesh if not provided.
+   Can optionally specify explicit bbox:
+   ```bash
+   --voxel 0.1 --bbox-min -10 -10 -10 --bbox-max 10 10 10
+   ```
+
+2. **Dimension Mode**:
+   ```bash
+   --dim 256
+   ```
+   Uses grid dimension to compute voxel size from bounding box. Bounding box is auto-computed from mesh if not provided.
+   Can optionally specify explicit bbox:
+   ```bash
+   --dim 256 --bbox-min -10 -10 -10 --bbox-max 10 10 10
+   ```
+
+**USD I/O:**
+
+The script uses Pixar's USD library for both reading and writing:
+- Reads arbitrary USD mesh prims
+- Handles triangles, quads, and n-gons (triangulated with fan method)
+
+**Mesh Topology:**
+
+- Input: Supports mixed triangle/quad meshes and n-gons
+- N-gons (faces with 5+ vertices) are automatically triangulated using fan triangulation
+
+#### Examples
+
+**Convert a simple mesh** (creates `sphere-out.vdb`):
+```bash
+python shrink_wrap.py sphere.usd --voxel 0.5
+```
+
+**High-resolution conversion with custom parameters** (creates `detailed_mesh-out.vdb`):
+```bash
+python shrink_wrap.py detailed_mesh.usd \
+    --voxel 0.01 \
+    --erode 5.0 \
+    --half-width 5.0
+```
+
+**Convert to simplified mesh** (creates `input-out.usd`):
+```bash
+python shrink_wrap.py input.usd \
+    --to-mesh \
+    --voxel 0.1 \
+    --adaptivity 0.005
+```
+
+**Create multiple LOD meshes** (creates `input-out_lod0.usd`, `input-out_lod1.usd`, etc.):
+```bash
+# Without --finest-only, this creates multiple LOD files
+python shrink_wrap.py input.usd \
+    --to-mesh \
+    --voxel 0.1
+```
+
+#### Verifying Output
+
+**VDB files:**
+```bash
+# View grid metadata
+vdb_print input-out.vdb
+
+# Visualize (if available)
+vdb_view input-out.vdb
+```
+
+**USD files:**
+```bash
+# View mesh (requires usd-core with usdview)
+usdview input-out.usd
+```
+
+#### Troubleshooting
+
+**Error: "pxr.Usd not found"**
+```bash
+pip install usd-core
+```
+
+**Error: "openvdb module not found"**
+
+Build OpenVDB Python bindings:
+```bash
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=$HOME/openvdb -DOPENVDB_BUILD_CORE=ON -DOPENVDB_BUILD_PYTHON_MODULE=ON -DOPENVDB_BUILD_VDB_LOD=ON -DOPENVDB_BUILD_VDB_RENDER=ON -DOPENVDB_BUILD_VDB_VIEW=ON -DOPENVDB_BUILD_VDB_TOOL=ON ..
+make -j4
+make install
+```
+
+**Error: "No mesh found in USD file"**
+
+Check that your USD file contains a mesh prim:
+```bash
+usdcat input.usd  # View USD contents
+```
+
+#### Performance Tips
+
+- **Voxel Size**: Larger voxel sizes = faster conversion, less memory
+- **Erode Parameter**: Lower values = faster but may lose thin features
+- **Closing Threshold Parameter**: Feature size for closing holes
+- **Finest Only**: Use `--finest-only` if you don't need LOD pyramid
+- **Adaptivity**: Higher values = faster mesh output but less detail
+
+#### See Also
+
+- OpenVDB Documentation: https://www.openvdb.org/documentation/
+- USD Documentation: https://openusd.org/
+- `vdb_tool` command-line utility for additional VDB operations

--- a/shrink-wrap-python/shrink_wrap.py
+++ b/shrink-wrap-python/shrink_wrap.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""
+Shrink Wrap - USD Mesh to Level Set Conversion
+
+Reads a mesh from a USD file, converts it to OpenVDB level sets,
+and optionally converts back to mesh or saves as .vdb file.
+
+Dependencies:
+    - openvdb (Python bindings)
+    - numpy
+    - usd-core (install with: pip install usd-core)
+
+Example usage:
+    # Convert USD mesh to VDB level set (creates input-out.vdb)
+    python shrink_wrap.py input.usd --voxel 0.1
+
+    # Convert to mesh with adaptivity (creates input-out.usd)
+    python shrink_wrap.py input.usd --to-mesh --voxel 0.1 --adaptivity 0.005
+
+    # Use dimension-based sizing
+    python shrink_wrap.py input.usd --dim 256
+"""
+
+import argparse
+import sys
+import os
+import numpy as np
+
+# Import required dependencies with helpful error messages
+try:
+    import openvdb
+except ImportError:
+    print("Error: openvdb module not found.", file=sys.stderr)
+    print("Build OpenVDB Python bindings with: cmake -DOPENVDB_BUILD_PYTHON_MODULE=ON", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    from usd_utils import USDInterface
+except ImportError:
+    print("Error: usd_utils module not found.", file=sys.stderr)
+    print("Make sure usd_utils.py is in openvdb/openvdb/python/examples/", file=sys.stderr)
+    print("Install USD support with: pip install usd-core", file=sys.stderr)
+    sys.exit(1)
+
+
+def generate_output_filename(input_path, to_mesh=False):
+    """Generate output filename from input path.
+
+    Output is created in the same directory as the input file.
+
+    Args:
+        input_path: Input USD file path
+        to_mesh: Whether converting to mesh (determines extension)
+
+    Returns:
+        Output filename with format: <input_dir>/<basename>-out.vdb or .usd
+    """
+    # Get directory and base filename without extension
+    input_dir = os.path.dirname(input_path)
+    base = os.path.splitext(os.path.basename(input_path))[0]
+
+    # Determine extension based on mode
+    ext = "usd" if to_mesh else "vdb"
+
+    # Generate output filename in same directory as input
+    output_filename = f"{base}-out.{ext}"
+    if input_dir:
+        output_filename = os.path.join(input_dir, output_filename)
+
+    return output_filename
+
+
+def read_mesh_from_usd(usd_path, verbose=False):
+    """Read mesh data from USD file using USDInterface.
+
+    This function loads all meshes from the USD file, applies world transformations,
+    merges them, and triangulates all faces.
+
+    Args:
+        usd_path: Path to USD file
+        verbose: Whether to print loading information (default: False)
+
+    Returns:
+        Tuple of (vertices, triangles) where:
+        - vertices: (N, 3) float32 numpy array
+        - triangles: (M, 3) numpy array
+
+    Raises:
+        ValueError: If no mesh found in USD file or if USD loading fails
+    """
+    try:
+        usd_interface = USDInterface(usd_path, verbose=verbose)
+    except Exception as e:
+        raise ValueError(f"Failed to load USD file: {e}")
+
+    vertices = usd_interface.merged_verts.astype(np.float32)
+    triangles = usd_interface.merged_faces.astype(np.uint32)
+
+    if len(vertices) == 0 or len(triangles) == 0:
+        raise ValueError(f"No valid mesh data found in {usd_path}")
+
+    return vertices, triangles
+
+
+def polygon_soup_to_level_set(vertices, triangles, quads=None,
+                              min_voxel_size=None, dim=None,
+                              bbox_min=None, bbox_max=None,
+                              erode=8.0, thres=0.0, half_width=3.0):
+    """Convert polygon soup to level set grids (LOD pyramid).
+
+    Args:
+        vertices: (N, 3) float32 numpy array
+        triangles: (M, 3) uint32 numpy array or None
+        quads: (K, 4) uint32 numpy array or None
+        min_voxel_size: Minimum voxel size for finest grid (required for voxel mode)
+        dim: Grid dimension (alternative to min_voxel_size)
+        bbox_min: Bounding box minimum (optional, tuple of 3 floats)
+        bbox_max: Bounding box maximum (optional, tuple of 3 floats)
+        erode: Maximum deformation allowed (default: 8.0)
+        thres: Closing threshold (default: 0.0)
+        half_width: Narrow band half-width in voxels (default: 3.0)
+
+    Returns:
+        List of openvdb.FloatGrid objects (finest to coarsest)
+
+    Raises:
+        ValueError: If no triangles or quads provided, or if required parameters missing
+    """
+    # Validate inputs
+    if triangles is None and quads is None:
+        raise ValueError("Must provide triangles or quads (or both)")
+
+    # Auto-compute bbox if not provided
+    if bbox_min is None or bbox_max is None:
+        bbox_min = tuple(vertices.min(axis=0))
+        bbox_max = tuple(vertices.max(axis=0))
+
+    # Choose overload based on provided parameters
+    if dim is not None:
+        # Overload 2: dimension + bbox
+        grids = openvdb.FloatGrid.convertPolygonSoupToLevelSet(
+            dim=dim,
+            bboxMin=bbox_min,
+            bboxMax=bbox_max,
+            points=vertices,
+            triangles=triangles,
+            quads=quads,
+            erode=erode,
+            thres=thres,
+            halfWidth=half_width
+        )
+
+    elif min_voxel_size is not None:
+        # Overload 3: minVoxelSize + bbox
+        grids = openvdb.FloatGrid.convertPolygonSoupToLevelSet(
+            minVoxelSize=min_voxel_size,
+            bboxMin=bbox_min,
+            bboxMax=bbox_max,
+            points=vertices,
+            triangles=triangles,
+            quads=quads,
+            erode=erode,
+            thres=thres,
+            halfWidth=half_width
+        )
+
+    else:
+        raise ValueError("Must specify either --voxel or --dim parameter")
+
+    return grids
+
+
+def levelset_to_mesh(grid, isovalue=0.0, adaptivity=0.0):
+    """Convert level set grid back to mesh.
+
+    Args:
+        grid: openvdb.FloatGrid
+        isovalue: Isosurface value (default: 0.0 for zero crossing)
+        adaptivity: Mesh simplification (0=none, 1=max, default: 0.0)
+
+    Returns:
+        (points, triangles, quads) numpy arrays
+    """
+    points, triangles, quads = grid.convertToPolygons(
+        isovalue=isovalue,
+        adaptivity=adaptivity
+    )
+    return points, triangles, quads
+
+
+def write_grids_to_vdb(vdb_path, grids, grid_names=None):
+    """Write list of grids to .vdb file.
+
+    Args:
+        vdb_path: Output .vdb file path
+        grids: List of openvdb grids
+        grid_names: Optional list of names for grids (default: "grid_0", "grid_1", ...)
+
+    """
+    # Set grid names
+    if grid_names is None:
+        grid_names = [f"grid_{i}" for i in range(len(grids))]
+
+    for grid, name in zip(grids, grid_names):
+        grid.name = name
+
+    # Write all grids to single file
+    openvdb.write(vdb_path, grids)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Shrink Wrap - Convert USD mesh to OpenVDB level sets",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Convert USD mesh to VDB with voxel size (creates input-out.vdb)
+  %(prog)s input.usd --voxel 0.1
+
+  # Convert to mesh with adaptivity (creates input-out.usd)
+  %(prog)s input.usd --to-mesh --voxel 0.1 --adaptivity 0.005
+
+  # Use dimension-based sizing
+  %(prog)s input.usd --dim 256
+        """
+    )
+
+    # Input/output
+    parser.add_argument("input_usd", help="Input USD mesh file")
+
+    # Conversion mode
+    parser.add_argument("--to-mesh", action="store_true",
+                       help="Convert grids back to mesh (output as USD)")
+
+    # Level set parameters
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--voxel", type=float,
+                      help="Voxel size for level set (required, uses minVoxelSize + bbox)")
+    group.add_argument("--dim", type=int,
+                      help="Grid dimension for finest level (uses dimension + bbox)")
+
+    parser.add_argument("--bbox-min", type=float, nargs=3, metavar=("X", "Y", "Z"),
+                       help="Bounding box minimum (optional, auto-computed from mesh if not provided)")
+    parser.add_argument("--bbox-max", type=float, nargs=3, metavar=("X", "Y", "Z"),
+                       help="Bounding box maximum (optional, auto-computed from mesh if not provided)")
+
+    parser.add_argument("--erode", type=float, default=8.0,
+                       help="Maximum deformation allowed (default: 8.0)")
+    parser.add_argument("--threshold", type=float, default=0.0,
+                       help="Closing threshold (default: 0.0)")
+    parser.add_argument("--half-width", type=float, default=3.0,
+                       help="Narrow band half-width in voxels (default: 3.0)")
+
+    # Mesh conversion parameters
+    parser.add_argument("--adaptivity", type=float, default=0.0,
+                       help="Mesh adaptivity for convertToPolygons (0-1, default: 0.0)")
+    parser.add_argument("--isovalue", type=float, default=0.0,
+                       help="Isovalue for mesh extraction (default: 0.0)")
+
+    # Output options
+    parser.add_argument("--finest-only", action="store_true",
+                       help="Only write finest grid (do not write entire LOD pyramid)")
+
+    args = parser.parse_args()
+
+    # Validate inputs
+    if not os.path.exists(args.input_usd):
+        print(f"Error: Input file not found: {args.input_usd}", file=sys.stderr)
+        return 1
+
+    # Generate output filename based on input and mode
+    args.output = generate_output_filename(args.input_usd, args.to_mesh)
+    print(f"Output file: {args.output}")
+
+    # Step 1: Read mesh from USD
+    print(f"Reading mesh from {args.input_usd}...")
+    try:
+        vertices, triangles = read_mesh_from_usd(args.input_usd, verbose=False)
+    except Exception as e:
+        print(f"Error reading USD file: {e}", file=sys.stderr)
+        return 1
+
+    print(f"  Vertices: {len(vertices)}")
+    print(f"  Triangles: {len(triangles)}")
+
+    # Step 2: Convert to level sets
+    print("\nConverting to level sets...")
+
+    bbox_min = tuple(args.bbox_min) if args.bbox_min else None
+    bbox_max = tuple(args.bbox_max) if args.bbox_max else None
+
+    try:
+        grids = polygon_soup_to_level_set(
+            vertices, triangles,
+            min_voxel_size=args.voxel,
+            dim=args.dim,
+            bbox_min=bbox_min,
+            bbox_max=bbox_max,
+            erode=args.erode,
+            thres=args.threshold,
+            half_width=args.half_width
+        )
+    except Exception as e:
+        print(f"Error converting to level set: {e}", file=sys.stderr)
+        return 1
+
+    print(f"  Generated {len(grids)} LOD grid(s):")
+    for i, grid in enumerate(grids):
+        voxel_size = grid.transform.voxelSize()[0]
+        active_count = grid.activeVoxelCount()
+        print(f"    Grid {i}: voxel_size={voxel_size:.4f}, active_voxels={active_count:,}")
+
+    # Step 3: Output
+    if args.to_mesh:
+        # Convert back to mesh and save as USD
+        print(f"\nConverting grids to mesh...")
+
+        if args.finest_only:
+            grids_to_convert = [grids[0]]
+        else:
+            grids_to_convert = grids
+
+        try:
+            # Convert each grid and write separate USD files (or combine)
+            if len(grids_to_convert) == 1:
+                grid = grids_to_convert[0]
+                points, tris, quads_out = levelset_to_mesh(grid, args.isovalue, args.adaptivity)
+
+                print(f"  Output mesh: {len(points)} vertices, {len(tris)} triangles, {len(quads_out)} quads")
+
+                # Write using USDInterface (preserves quads)
+                USDInterface.write_file(args.output, points, tris, quads_out)
+                print(f"\nWrote mesh to {args.output}")
+            else:
+                # Multiple grids - write each to separate USD
+                base, ext = os.path.splitext(args.output)
+                for i, grid in enumerate(grids_to_convert):
+                    points, tris, quads_out = levelset_to_mesh(grid, args.isovalue, args.adaptivity)
+                    output_path = f"{base}_lod{i}{ext}"
+
+                    USDInterface.write_file(output_path, points, tris, quads_out, mesh_name=f"Mesh_LOD{i}")
+                    print(f"  Wrote LOD {i} to {output_path}")
+        except Exception as e:
+            print(f"Error converting to mesh: {e}", file=sys.stderr)
+            return 1
+    else:
+        # Save as .vdb file
+        print(f"\nWriting grids to {args.output}...")
+
+        if args.finest_only:
+            grids_to_save = [grids[0]]
+            grid_names = ["level_set"]
+        else:
+            grids_to_save = grids
+            grid_names = [f"level_set_lod{i}" for i in range(len(grids))]
+
+        try:
+            write_grids_to_vdb(args.output, grids_to_save, grid_names)
+            print(f"  Wrote {len(grids_to_save)} grid(s) to {args.output}")
+        except Exception as e:
+            print(f"Error writing VDB file: {e}", file=sys.stderr)
+            return 1
+
+    print("\nDone!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shrink-wrap-python/usd_utils.py
+++ b/shrink-wrap-python/usd_utils.py
@@ -1,0 +1,273 @@
+import numpy as np
+
+
+have_pxr_lib = False
+try: 
+    # conditionally load so it is an optional dependency
+    import pxr  # USD support
+    from pxr import Usd, UsdGeom
+    have_pxr_lib = True
+except ImportError: 
+    pass
+
+# See https://github.com/ColinKennedy/USD-Cookbook/blob/master/tricks/traverse_instanced_prims/README.md
+def traverse_instanced_children(prim):
+    """Get every Prim child beneath `prim`, even if `prim` is instanced.
+
+    Important:
+        If `prim` is instanced, any child that this function yields will
+        be an instance proxy.
+
+    Args:
+        prim (`pxr.Usd.Prim`): Some Prim to check for children.
+
+    Yields:
+        `pxr.Usd.Prim`: The children of `prim`.
+
+    """
+    for child in prim.GetFilteredChildren(Usd.TraverseInstanceProxies()):
+        yield child
+
+        for subchild in traverse_instanced_children(child):
+            yield subchild
+
+
+def simple_triangulate_faces(face_vertex_counts, face_vertex_inds_flat):
+    """
+    Given a polygonal mesh (with arbitrary degree faces) in a flat list representation, triangulates the faces, and returns a new (Tx3) numpy array.
+
+    This is a naive pure-python for-loop, so it will be slow for large meshes. 
+    TODO write some clever numpy or something.
+    """
+
+    tri_faces = []
+    i_start = 0
+    for i_face in range(len(face_vertex_counts)):
+        D = face_vertex_counts[i_face]
+        i_end = i_start + D
+        for k in range(1, D - 1):
+            # fan tesselation with first vertex as root
+            tri_faces.append((face_vertex_inds_flat[i_start],
+                              face_vertex_inds_flat[i_start + k],
+                              face_vertex_inds_flat[i_start + k + 1]))
+
+        i_start = i_end
+
+    return np.array(tri_faces, dtype=face_vertex_inds_flat.dtype)
+
+
+def merge_meshes(verts_list, faces_list):
+    """Merge multiple meshes into a single mesh.
+
+    Concatenates vertices and adjusts face indices to account for the offset
+    from combining vertex arrays.
+
+    Args:
+        verts_list: List of vertex arrays, each (N_i, 3)
+        faces_list: List of face index arrays, each (M_i, 3) or (M_i, 4)
+
+    Returns:
+        Tuple of (combined_verts, combined_faces):
+        - combined_verts: (N_total, 3) array with all vertices
+        - combined_faces: (M_total, 3/4) array with adjusted face indices
+    """
+    N = len(verts_list)
+
+    # Shift face indices to account for vertex concatenation
+    # Each mesh's face indices need to be offset by the total number
+    # of vertices from all previous meshes
+    v_sum = 0  # Running sum of vertex counts
+    faces_list_shifted = []
+    for i in range(N):
+        # Add vertex offset to all face indices in this mesh
+        faces_list_shifted.append(faces_list[i] + v_sum)
+        v_sum += verts_list[i].shape[0]
+
+    # Concatenate all vertices and adjusted faces
+    combined_verts = np.concatenate(verts_list, axis=0)
+    combined_faces = np.concatenate(faces_list_shifted, axis=0)
+
+    return combined_verts, combined_faces
+
+
+def get_world_transform(prim):
+    """
+    Get the local transformation of a prim using Xformable.
+    See https://graphics.pixar.com/usd/release/api/class_usd_geom_xformable.html
+    Args:
+        prim: The prim to calculate the world transformation.
+    Returns:
+        4x4 world object --> world transformation matrix
+    """
+
+    # https://docs.omniverse.nvidia.com/prod_kit/prod_kit/programmer_ref/usd/transforms/get-world-transforms.html
+
+    xform = UsdGeom.Xformable(prim)
+    time = Usd.TimeCode.Default(
+    )  # The time at which we compute the bounding box
+    world_transform = xform.ComputeLocalToWorldTransform(time)
+    mat = np.array(world_transform)
+    return mat
+
+    # translation: Gf.Vec3d = world_transform.ExtractTranslation()
+    # rotation: Gf.Rotation = world_transform.ExtractRotation()
+    # scale: Gf.Vec3d = Gf.Vec3d(*(v.GetLength() for v in world_transform.ExtractRotationMatrix()))
+    # return translation, rotation, scale
+
+
+class USDInterface:
+
+    def __init__(self, usd_path, verbose=True):
+
+        if not have_pxr_lib:
+            raise ValueError("USD support is not available, try `pip install usd-core`")
+
+        self.usd_path = usd_path
+        self.verbose = verbose
+        self.load_file()
+
+    def load_file(self):
+        """Load and process all meshes from the USD file.
+
+        This method:
+        1. Opens the USD stage and discovers all mesh prims (including instanced)
+        2. Extracts vertices and faces from each mesh
+        3. Triangulates all n-gon faces using fan tessellation
+        4. Applies world transformations to vertices
+        5. Merges all meshes into single arrays
+        6. Converts coordinate system from Z-up to Y-up
+
+        Sets instance variables:
+            self.stage: USD stage object
+            self.root_prim: Root prim of the stage
+            self.mesh_prims: List of UsdGeom.Mesh prims found
+            self.merged_verts: (N, 3) array of all vertices in world space
+            self.merged_faces: (M, 3) array of all triangle faces
+            self.merged_faces_source_prim: (M,) array indicating source prim index for each face
+        """
+        # Open the USD file
+        if self.verbose: 
+            print(f"USD: loading {self.usd_path}")
+        self.stage = Usd.Stage.Open(self.usd_path)
+        self.root_prim = self.stage.GetPseudoRoot()
+
+        # Discover all mesh prims in the scene hierarchy
+        # traverse_instanced_children handles instanced geometry properly
+        self.mesh_prims = []
+        for prim in traverse_instanced_children(self.root_prim):
+            if self.verbose: 
+                print(f"  USD traversing: {prim.GetPath()}")
+
+            if prim.IsA(UsdGeom.Mesh):
+                self.mesh_prims.append(prim)
+
+        if self.verbose:
+            print(f"USD: found {len(self.mesh_prims)} mesh prims in file")
+
+        # Collect vertices and faces from all meshes
+        verts_list = []
+        faces_list = []
+        face_source_prim_list = []  # Track which prim each face came from
+
+        for ip, p in enumerate(self.mesh_prims):
+            if self.verbose:
+                print(f"  mesh prim: {p.GetPath()}")
+            mesh = UsdGeom.Mesh(p)
+
+            # Extract face topology (USD stores as flat arrays)
+            # face_vertex_counts: [3, 4, 3, ...] - vertices per face
+            # face_vertex_inds_flat: [0, 1, 2, 0, 2, 3, 4, ...] - flattened indices
+            face_vertex_counts = np.array(mesh.GetFaceVertexCountsAttr().Get(), dtype=np.longlong)
+            face_vertex_inds_flat = np.array(mesh.GetFaceVertexIndicesAttr().Get(), dtype=np.longlong)
+
+            # Triangulate all faces (converts quads/n-gons to triangles)
+            tri_faces = simple_triangulate_faces(face_vertex_counts, face_vertex_inds_flat)
+            vertices = np.array(mesh.GetPointsAttr().Get())
+
+            # Apply world transformation to get vertices in world space
+            # This handles translation, rotation, scale, and parenting
+            tmat = get_world_transform(p)
+            # Convert to homogeneous coordinates (add w=1)
+            vertices_homog = np.concatenate((vertices, np.ones_like(vertices[:, 0:1])), axis=-1)
+            # Apply 4x4 transform and extract xyz
+            vertices = (vertices_homog @ tmat)[:, :3]
+
+            verts_list.append(vertices)
+            faces_list.append(tri_faces)
+
+            # Tag each face with its source prim index for debugging
+            face_source_prim = np.zeros_like(tri_faces[:, 0]) + ip
+            face_source_prim_list.append(face_source_prim)
+
+        # Merge all meshes into single vertex/face arrays
+        self.merged_verts, self.merged_faces = merge_meshes(verts_list, faces_list)
+        self.merged_faces_source_prim = np.concatenate(face_source_prim_list, axis=0)
+
+        # Convert from Z-up (USD convention) to Y-up (OpenVDB convention)
+        # np.roll shifts axis order: [x, y, z] -> [z, x, y] -> use as [x, y, z] in Y-up
+        self.merged_verts = np.roll(self.merged_verts, 2, axis=-1)
+
+        if False:
+            import polyscope as ps  # for debugging only
+            ps.init()
+            ps.set_up_dir("y_up")
+            ps_mesh = ps.register_surface_mesh("usd mesh", self.merged_verts, self.merged_faces)
+            ps_mesh.add_scalar_quantity("source prim", self.merged_faces_source_prim, defined_on='faces')
+            ps.show()
+
+        if self.verbose:
+            print(f"USD: loaded full mesh of {self.merged_verts.shape[0]} verts and {self.merged_faces.shape[0]} faces.")
+
+    @staticmethod
+    def write_file(usd_path, points, triangles=None, quads=None, mesh_name="Mesh"):
+        """Write mesh to USD file using Pixar's USD library.
+
+        Preserves both triangles and quads without triangulation.
+
+        Args:
+            usd_path: Output USD file path
+            points: (N, 3) numpy array of vertices
+            triangles: (M, 3) numpy array or None
+            quads: (K, 4) numpy array or None
+            mesh_name: Name for the mesh prim (default: "Mesh")
+
+        Raises:
+            ValueError: If USD support not available or no triangles/quads provided
+        """
+        if not have_pxr_lib:
+            raise ValueError("USD support is not available, try `pip install usd-core`")
+
+        from pxr import Vt, Sdf
+
+        # Create new stage
+        stage = Usd.Stage.CreateNew(usd_path)
+
+        # Create mesh prim
+        mesh_path = Sdf.Path(f"/{mesh_name}")
+        mesh = UsdGeom.Mesh.Define(stage, mesh_path)
+
+        # Set vertices
+        mesh.GetPointsAttr().Set(Vt.Vec3fArray.FromNumpy(points))
+
+        # Combine triangles and quads into face data
+        face_vertex_indices = []
+        face_vertex_counts = []
+
+        if triangles is not None and len(triangles) > 0:
+            for tri in triangles:
+                face_vertex_indices.extend([int(x) for x in tri])
+                face_vertex_counts.append(3)
+
+        if quads is not None and len(quads) > 0:
+            for quad in quads:
+                face_vertex_indices.extend([int(x) for x in quad])
+                face_vertex_counts.append(4)
+
+        if not face_vertex_indices:
+            raise ValueError("No triangles or quads provided")
+
+        mesh.GetFaceVertexIndicesAttr().Set(Vt.IntArray(face_vertex_indices))
+        mesh.GetFaceVertexCountsAttr().Set(Vt.IntArray(face_vertex_counts))
+
+        # Save stage
+        stage.GetRootLayer().Save()


### PR DESCRIPTION
This commit adds Python bindings for OpenVDB's polySoupToLevelSet tool and introduces a new shrink-wrap utility for converting USD meshes to OpenVDB level sets with automatic LOD pyramid generation.

Python Bindings (pyGrid.h):
- Added convertPolygonSoupToLevelSet() with three overloads:
  1. minVoxelSize + maxVoxelSize
  2. dimension + bounding box
  3. minVoxelSize + bounding box
- Returns list of grids (LOD pyramid) from finest to coarsest
- Supports triangles, quads, or mixed topology
- Includes shrink-wrap deformation (erode, thres parameters)
- Only available on floating-point grids (FloatGrid, DoubleGrid)

Unit Tests (TestOpenVDB.py):
- Added testConvertPolygonSoupToLevelSet() covering all three overloads
- Tests LOD pyramid validation, background values, active voxel counts
- Verifies type safety (unavailable on BoolGrid, Vec3SGrid)
- 153 lines of comprehensive test coverage

Shrink-Wrap Utility (shrink-wrap-python/):
- New command-line tool for USD to VDB conversion
- Simplified CLI: auto-generates output filenames from input
  * Default: input.usd -> input-out.vdb
  * With --to-mesh: input.usd -> input-out.usd
  * Multi-LOD: input-out_lod0.usd, input-out_lod1.usd, etc.
- Supports multiple conversion modes (voxel size, dimension)
- Optional mesh reconstruction with adaptivity
- Comprehensive error handling and validation
- Full documentation in README.md (220+ lines)

Dependencies:
- numpy, usd-core (pip install usd-core)
- OpenVDB Python bindings

Files:
- Modified: pyGrid.h (+246), TestOpenVDB.py (+153)
- Added: shrink-wrap-python/ (README.md, shrink_wrap.py, usd_utils.py)